### PR TITLE
build: add placeholder versions

### DIFF
--- a/generator/templates/_package.json
+++ b/generator/templates/_package.json
@@ -1,5 +1,6 @@
 {
   "name": "@open-screeps/<%= moduleName %>",
+  "version": "0.0.0-development",
   "description": "<%= moduleDescription %>",
   "main": "index.js",
   "scripts": {

--- a/src/is-invader/package.json
+++ b/src/is-invader/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@open-screeps/is-invader",
+  "version": "0.0.0-development",
   "description": "Check if something is an Invader",
   "main": "index.js",
   "scripts": {

--- a/src/is-room-visible/package.json
+++ b/src/is-room-visible/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@open-screeps/is-room-visible",
+  "version": "0.0.0-development",
   "description": "Check whether a room is currently visible",
   "main": "index.js",
   "scripts": {

--- a/src/is-source-keeper/package.json
+++ b/src/is-source-keeper/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@open-screeps/is-source-keeper",
+  "version": "0.0.0-development",
   "description": "Check is something is a Source Keeper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes an issue which prevents us from publishing to npm as this requires us to provide a
version field. The @semantic-release/npm module opted to only replace the version instead of adding
it to the `package.json`, an issue has been created in semantic-release/npm#27.
