### PR TITLE
feat: is-creep-alive function

### DIFF
--- a/src/is-creep-alive/index.ts
+++ b/src/is-creep-alive/index.ts
@@ -1,0 +1,3 @@
+export function isCreepAlive(creep: string): boolean {
+	return creep in Game.creeps;
+}

--- a/src/is-creep-alive/package.json
+++ b/src/is-creep-alive/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@open-screeps/is-creep-alive",
+  "version": "0.0.0-development",
+  "description": "Returns true if the creep is alive",
+  "main": "index.js",
+  "scripts": {
+    "lint": "tslint -p ./tsconfig.json",
+    "test": "tsc && nyc ava",
+    "prepare": "npm test",
+    "release": "semantic-release -e semantic-release-monorepo"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/postcrafter/open-screeps.git"
+  },
+  "files": [
+    "index.{d.ts,js,js.map}"
+  ],
+  "keywords": [
+    "screeps",
+    "open-screeps"
+  ],
+  "author": "Adam Laycock &lt;adam&#39;arcath.net&gt;",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/postcrafter/open-screeps/issues"
+  },
+  "homepage": "https://github.com/postcrafter/open-screeps/src/is-creep-alive#readme",
+  "dependencies": {
+    "@types/screeps": "^0.0.0"
+  },
+  "devDependencies": {
+    "ava": "^0.24.0",
+    "condition-circle": "^2.0.1",
+    "nyc": "^11.3.0",
+    "semantic-release": "^11.0.2",
+    "semantic-release-monorepo": "^4.0.0",
+    "tslint": "^5.9.1",
+    "tslint-config-airbnb": "^5.4.2",
+    "typescript": "^2.6.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "release": {
+    "verifyConditions": "condition-circle"
+  }
+}

--- a/src/is-creep-alive/readme.md
+++ b/src/is-creep-alive/readme.md
@@ -1,0 +1,17 @@
+# is-creep-alive
+> Returns true if the creep is alive
+
+## Install
+```sh
+$ npm install @open-screeps/is-creep-alive
+```
+
+## Usage
+```typescript
+import { example } from '@open-screeps/is-creep-alive';
+```
+
+## Related
+
+## License
+[MIT](../../license.md)

--- a/src/is-creep-alive/readme.md
+++ b/src/is-creep-alive/readme.md
@@ -8,10 +8,13 @@ $ npm install @open-screeps/is-creep-alive
 
 ## Usage
 ```typescript
-import { example } from '@open-screeps/is-creep-alive';
+import { isCreepAlive } from '@open-screeps/is-creep-alive';
+
+const livingCreeps = _.filter(Memory.creepList, (creepName) => isCreepAlive(creepName))
 ```
 
 ## Related
+- [is-room-visible](https://github.com/PostCrafter/open-screeps/tree/master/src/is-room-visible)
 
 ## License
 [MIT](../../license.md)

--- a/src/is-creep-alive/test.ts
+++ b/src/is-creep-alive/test.ts
@@ -1,0 +1,21 @@
+import ava from 'ava';
+
+import { isCreepAlive } from './index';
+
+declare const global: any;
+
+function stubGame() {
+	global.Game = {
+		creeps: {
+			dave: {},
+			bob: {},
+		},
+	};
+}
+
+ava('Should return the right values for is creep alive', (t) => {
+	stubGame();
+
+	t.true(isCreepAlive('dave'));
+	t.false(isCreepAlive('phil'));
+});

--- a/src/is-creep-alive/tsconfig.json
+++ b/src/is-creep-alive/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}


### PR DESCRIPTION
Adds `is-creep-alive` which is very similar to `is-room-visible`.

Thinking this will be more useful for some creep functions I'd like to make as a first step check to ensure that the given creep is alive before we do anything.
