### PR TITLE
fix: generated test.ts has some linting errors

### DIFF
--- a/generator/templates/test.ts
+++ b/generator/templates/test.ts
@@ -1,8 +1,8 @@
-import test from 'ava';
+import ava from 'ava';
 
 import { example } from './index';
 
-test('Should act as an example to be used as a template', t => {
+ava('Should act as an example to be used as a template', (t) => {
 	example();
 	t.pass('Calls example() once in order to trigger code coverage');
 });


### PR DESCRIPTION
`test.ts` had a couple of linting errors.

 - `ava` should be imported as `ava` not `test`
 - `t =>` should be `(t) =>`