### PR TITLE
feat: tower effectiveness at range

### DIFF
--- a/src/tower-effectiveness-at-range/index.ts
+++ b/src/tower-effectiveness-at-range/index.ts
@@ -1,0 +1,29 @@
+export function towerEffectivenessAtRange(
+	range: number,
+	action: 'attack' | 'heal' | 'repair' = 'attack',
+): number {
+	let max: number = 0;
+
+	switch (action) {
+	case 'attack':
+		max = TOWER_POWER_ATTACK;
+		break;
+	case 'heal':
+		max = TOWER_POWER_HEAL;
+		break;
+	case 'repair':
+		max = TOWER_POWER_REPAIR;
+		break;
+	}
+
+	if (range <= TOWER_OPTIMAL_RANGE) {
+		return max;
+ 	}
+	if (range >= TOWER_FALLOFF_RANGE) {
+		return max  * (1 - TOWER_FALLOFF);
+ 	}
+
+	const towerFalloffPerTile = TOWER_FALLOFF / (TOWER_FALLOFF_RANGE - TOWER_OPTIMAL_RANGE);
+
+	return max * (1 - (range - TOWER_OPTIMAL_RANGE) * towerFalloffPerTile);
+}

--- a/src/tower-effectiveness-at-range/index.ts
+++ b/src/tower-effectiveness-at-range/index.ts
@@ -1,21 +1,7 @@
 export function towerEffectivenessAtRange(
 	range: number,
-	action: 'attack' | 'heal' | 'repair' = 'attack',
+	max: number,
 ): number {
-	let max: number = 0;
-
-	switch (action) {
-	case 'attack':
-		max = TOWER_POWER_ATTACK;
-		break;
-	case 'heal':
-		max = TOWER_POWER_HEAL;
-		break;
-	case 'repair':
-		max = TOWER_POWER_REPAIR;
-		break;
-	}
-
 	if (range <= TOWER_OPTIMAL_RANGE) {
 		return max;
  	}

--- a/src/tower-effectiveness-at-range/package.json
+++ b/src/tower-effectiveness-at-range/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@open-screeps/tower-effectiveness-at-range",
+  "version": "0.0.0-development",
+  "description": "Calculate the effectiveness of tower actions at the given range",
+  "main": "index.js",
+  "scripts": {
+    "lint": "tslint -p ./tsconfig.json",
+    "test": "tsc && nyc ava",
+    "prepare": "npm test",
+    "release": "semantic-release -e semantic-release-monorepo"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/postcrafter/open-screeps.git"
+  },
+  "files": [
+    "index.{d.ts,js,js.map}"
+  ],
+  "keywords": [
+    "screeps",
+    "open-screeps"
+  ],
+  "author": "Adam Laycock &lt;adam@arcath.net&gt;",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/postcrafter/open-screeps/issues"
+  },
+  "homepage": "https://github.com/postcrafter/open-screeps/src/tower-effectiveness-at-range#readme",
+  "dependencies": {
+    "@types/screeps": "^0.0.0"
+  },
+  "devDependencies": {
+    "ava": "^0.24.0",
+    "condition-circle": "^2.0.1",
+    "nyc": "^11.3.0",
+    "semantic-release": "^11.0.2",
+    "semantic-release-monorepo": "^4.0.0",
+    "tslint": "^5.9.1",
+    "tslint-config-airbnb": "^5.4.2",
+    "typescript": "^2.6.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "release": {
+    "verifyConditions": "condition-circle"
+  }
+}

--- a/src/tower-effectiveness-at-range/readme.md
+++ b/src/tower-effectiveness-at-range/readme.md
@@ -1,0 +1,23 @@
+# tower-effectiveness-at-range
+> Calculate the effectiveness of tower actions at the given range
+
+## Install
+```sh
+$ npm install @open-screeps/tower-effectiveness-at-range
+```
+
+## Usage
+```typescript
+import { towerEffectivenessAtRange } from '@open-screeps/tower-effectiveness-at-range';
+
+let damage = towerEffectivenessAtRange(creep.pos.getRangeTo(tower));
+
+let heal = towerEffectivenessAtRange(creep.pos.getRangeTo(tower), 'heal');
+
+let repair = towerEffectivenessAtRange(container.pos.getRangeTo(tower), 'repair');
+```
+
+## Related
+
+## License
+[MIT](../../license.md)

--- a/src/tower-effectiveness-at-range/test.ts
+++ b/src/tower-effectiveness-at-range/test.ts
@@ -15,10 +15,10 @@ global.TOWER_FALLOFF_RANGE = 20;
 global.TOWER_FALLOFF = 0.75;
 
 ava('Should calculate the tower effectiveness for the given ranges', (t) => {
-	t.is(towerEffectivenessAtRange(2), 600);
-	t.is(towerEffectivenessAtRange(21), 150);
-	t.is(towerEffectivenessAtRange(10), 450);
-	t.is(towerEffectivenessAtRange(15), 300);
-	t.is(towerEffectivenessAtRange(2, 'heal'), 400);
-	t.is(towerEffectivenessAtRange(2, 'repair'), 800);
+	t.is(towerEffectivenessAtRange(2, TOWER_POWER_ATTACK), 600);
+	t.is(towerEffectivenessAtRange(21, TOWER_POWER_ATTACK), 150);
+	t.is(towerEffectivenessAtRange(10, TOWER_POWER_ATTACK), 450);
+	t.is(towerEffectivenessAtRange(15, TOWER_POWER_ATTACK), 300);
+	t.is(towerEffectivenessAtRange(2, TOWER_POWER_HEAL), 400);
+	t.is(towerEffectivenessAtRange(2, TOWER_POWER_REPAIR), 800);
 });

--- a/src/tower-effectiveness-at-range/test.ts
+++ b/src/tower-effectiveness-at-range/test.ts
@@ -1,0 +1,24 @@
+import ava from 'ava';
+
+import { towerEffectivenessAtRange } from './index';
+
+declare const global: any;
+
+global.TOWER_HITS = 3000;
+global.TOWER_CAPACITY = 1000;
+global.TOWER_ENERGY_COST = 10;
+global.TOWER_POWER_ATTACK = 600;
+global.TOWER_POWER_HEAL = 400;
+global.TOWER_POWER_REPAIR = 800;
+global.TOWER_OPTIMAL_RANGE = 5;
+global.TOWER_FALLOFF_RANGE = 20;
+global.TOWER_FALLOFF = 0.75;
+
+ava('Should calculate the tower effectiveness for the given ranges', (t) => {
+	t.is(towerEffectivenessAtRange(2), 600);
+	t.is(towerEffectivenessAtRange(21), 150);
+	t.is(towerEffectivenessAtRange(10), 450);
+	t.is(towerEffectivenessAtRange(15), 300);
+	t.is(towerEffectivenessAtRange(2, 'heal'), 400);
+	t.is(towerEffectivenessAtRange(2, 'repair'), 800);
+});

--- a/src/tower-effectiveness-at-range/tsconfig.json
+++ b/src/tower-effectiveness-at-range/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}


### PR DESCRIPTION
Calculates the effectiveness of tower actions at the given range.

By default it will calculate the attack power of the tower, if the second option is supplied it can calculate heal/repair as well.

Based off a comment by tigga in #help on slack

![image](https://user-images.githubusercontent.com/19609/35100016-14824bae-fc52-11e7-94d5-8d68323ddf5c.png)
